### PR TITLE
[N64] Implement most of CP0, couple other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ gen_mips_lut
 gen_arm_lut
 gen_sm83_lut
 *.a
+.idea/
+cmake-build-debug/

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "beyond-all-repair"]
 	path = beyond-all-repair
 	url = git@github.com:destoer/beyond-all-repair.git
+[submodule "spdlog"]
+	path = spdlog
+	url = git@github.com:gabime/spdlog.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,6 @@ if(WIN32)
 	find_package(SDL2 CONFIG REQUIRED)
 
 	target_link_libraries(albion SDL2::SDL2 spdlog::spdlog)
-	
-    include_directories("C:/SDL2-2.0.14/include")
 else()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Werror -Wall -Wextra -march=native -pthread -O1 -fomit-frame-pointer -Wno-missing-braces")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,14 @@
 cmake_minimum_required(VERSION 3.10)
 
 project(albion)
+include(FetchContent)
 
+add_subdirectory(spdlog)
+
+find_package(spdlog)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 
 #set(FRONTEND "QT")
 set(FRONTEND "SDL")
@@ -129,14 +132,19 @@ if(WIN32)
 	endif()
 
 
-	# sdl (allways needed)
-    add_library(SDL2 SHARED IMPORTED)
-    set_target_properties(SDL2 PROPERTIES
-        IMPORTED_LOCATION "C:/SDL2-2.0.14/lib/x64/SDL2.dll"
-        IMPORTED_IMPLIB "C:/SDL2-2.0.14/lib/x64/SDL2.lib"
-        LINKER_LANGUAGE C
-    )
-	target_link_libraries(albion SDL2)
+
+	# Fetch SDL for the runtime
+	FetchContent_Declare(
+			SDL2
+			URL https://www.libsdl.org/release/SDL2-devel-2.30.2-VC.zip
+	)
+	FetchContent_MakeAvailable(SDL2)
+	set(SDL2_DIR ${sdl2_SOURCE_DIR})
+	list(APPEND CMAKE_PREFIX_PATH "${sdl2_SOURCE_DIR}/cmake")
+
+	find_package(SDL2 CONFIG REQUIRED)
+
+	target_link_libraries(albion SDL2::SDL2 spdlog::spdlog)
 	
     include_directories("C:/SDL2-2.0.14/include")
 else()
@@ -145,7 +153,7 @@ else()
 	if(${FRONTEND} STREQUAL "HEADLESS")
 
 	else ()
-		target_link_libraries(albion SDL2)
+		target_link_libraries(albion SDL2 spdlog::spdlog)
 	endif()
 endif()
 

--- a/src/common/albion/emulator.cpp
+++ b/src/common/albion/emulator.cpp
@@ -36,8 +36,14 @@ emu_type get_emulator_type(std::string filename)
 
 	}
 
-    else 
-    {
-        return emu_type::none;
+    return emu_type::none;
+}
+
+std::string get_emulator_name(emu_type type) {
+    switch(type) {
+        case emu_type::gameboy: return "Gameboy";
+        case emu_type::gba: return "Gameboy Advance";
+        case emu_type::n64: return "Nintendo 64";
+        case emu_type::none: return "Invalid";
     }
 }

--- a/src/frontend/sdl/sdl_window.cpp
+++ b/src/frontend/sdl/sdl_window.cpp
@@ -14,6 +14,8 @@
 #ifdef N64_ENABLED
 #include <frontend/sdl/n64_window.h>
 #include "n64_window.cpp"
+#include "spdlog/spdlog.h"
+
 #endif
 
 #include <albion/destoer-emu.h>
@@ -23,7 +25,8 @@ void start_emu(std::string filename, Config& cfg)
 	try
 	{
 		const auto type = get_emulator_type(filename);
-	
+
+        spdlog::info("Starting", get_emulator_name(type), " emulator engine.");
 
 		switch(type)
 		{
@@ -56,8 +59,7 @@ void start_emu(std::string filename, Config& cfg)
 
 			default:
 			{
-				std::cout << "unrecognised rom type" 
-					<< filename << "\n";
+				spdlog::error("Unrecognised ROM type:", filename);
 			}
 		}
 	}
@@ -159,6 +161,8 @@ void SDLMainWindow::main(std::string filename, b32 start_debug)
 		auto control = input.handle_input(window);
 		
 		pass_input_to_core();
+
+
 
 		run_frame();
 

--- a/src/headers/albion/emulator.h
+++ b/src/headers/albion/emulator.h
@@ -13,3 +13,4 @@ enum class emu_test
 };
 
 emu_type get_emulator_type(std::string filename);
+std::string get_emulator_name(emu_type);

--- a/src/headers/n64/cop0.h
+++ b/src/headers/n64/cop0.h
@@ -10,17 +10,17 @@ struct Status
     b32 exl = 0;
     b32 erl = 0;
     u32 ksu = 0;
-    b32 ux = 0;
-    b32 sx = 0;
-    b32 kx = 0;
+    b32 ux = 1;
+    b32 sx = 1;
+    b32 kx = 1;
     u8 im = 0;
-    u32 ds = 0;
+    u32 ds = 0b10000;
     b32 re = 0;
-    b32 fr = 0;
+    b32 fr = 1;
     b32 rp = 0;
 
     b32 cu0 = false;
-    b32 cu1 = false;
+    b32 cu1 = true;
     b32 cu2 = false;
     b32 cu3 = false;    
 };
@@ -61,6 +61,30 @@ struct Context
     u32 pte_base = 0;
 };
 
+struct Config {
+    u8 freq = 0b111;
+    u8 transfer_mode = 0;
+    u8 endianness = 1;
+    u8 cu = 0;
+    u8 k0 = 0b11;
+};
+
+struct WatchLo {
+    u32 paddr0;
+    u8 read;
+    u8 write;
+};
+
+struct WatchHi {
+    u8 paddr1;
+};
+
+struct XConfig {
+    u32 pte;
+    u8 r;
+    u32 bad_vpn;
+};
+
 // TODO: factor these into structs
 struct Cop0
 {
@@ -85,16 +109,29 @@ struct Cop0
 
     // count and compare
     u32 count = 0;
-    u32 compare = 0; 
+    u32 compare = 0;
 
-    u32 random = 0;
+    u8 wired = 0;
 
-    u32 prid = 0;
-    u32 config = 0;
+    // random register set to 31 on init
+    u32 random = 0b11111;
+
+    u32 prid = 0xB22;
+    Config config;
 
     // cache tags (these have fields we just dont care about them)
-    u32 tag_hi = 0; 
-    u32 tag_lo = 0;
+    WatchHi watchHi;
+    WatchLo watchLo;
+
+    u32 tagLo;
+
+    u8 parity = 0;
+
+    XConfig xconfig;
+
+    u32 load_linked = ~0u;
+
+    void updateRandom();
 };
 
 }

--- a/src/headers/n64/cop0.h
+++ b/src/headers/n64/cop0.h
@@ -29,7 +29,7 @@ struct Cause
 {
     u32 exception_code = 0;
     u8 pending = 0;
-    u32 coprocessor_error = 0;
+    u32 coprocessor_error = 0b11;
     b32 branch_delay = 0;
 };
 

--- a/src/n64/cpu/cpu.cpp
+++ b/src/n64/cpu/cpu.cpp
@@ -41,9 +41,6 @@ void reset_cpu(N64 &n64)
     
 
     cop0.random = 0x0000001F;
-    write_cop0(n64,0x34000000,STATUS);
-    write_cop0(n64,0x00000B00,PRID);
-    write_cop0(n64,0x0006E463,CONFIG);
     write_cop0(n64,0,COUNT);
     write_cop0(n64,0,COMPARE);
     write_cop0(n64,0xffff'ffff,EPC);

--- a/src/n64/cpu/cpu.cpp
+++ b/src/n64/cpu/cpu.cpp
@@ -61,6 +61,7 @@ void reset_cpu(N64 &n64)
 void cycle_tick(N64 &n64, u32 cycles)
 {
     n64.scheduler.delay_tick(cycles);
+    n64.cpu.cop0.updateRandom();
 }
 
 


### PR DESCRIPTION
Passes all of the CP0 test ROMS.

SDL2 is downloaded automatically, removing the need for hardcoded paths.

SPDLog is now included, for easier control over log output levels than is afforded by the current write_log function (which can either log or not log), as spdlog allows six different write levels and filtering out log writes that aren't in the current log output level.

Some simple prints are wired in during initialization to demonstrate how spdlog works.